### PR TITLE
FIX Readme Typo + Add compse

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,26 @@ A simple flask interface to send wake on LAN commands. Just send a `POST` to `/w
 The official docker image is available at [Docker Hub](https://hub.docker.com/r/rix1337/docker-wol_api).
 
 # Run
-```
+
+## Docker Run
+
+```bash
 docker run -d \
   --name="WakeOnLAN-API" \
   -e PORT=8080 \
   --net=host \
-  rix1337/docker-wol-api
-  ```
+  rix1337/docker-wol_api
+```
  
+## Docker Compose
+
+```yaml
+version: '3.3'
+services:
+    docker-wol-api:
+        container_name: WakeOnLAN-API
+        environment:
+            - PORT=8893
+        network_mode: host
+        image: rix1337/docker-wol_api
+```


### PR DESCRIPTION
Image Name Typo:
- The docker-wol-api image does not exist in Docker Hub. 
- The image name has been replaced with docker-wol_api (https://registry.hub.docker.com/r/rix1337/docker-wol_api) 

Docker Compose:
- Added Docker Compose sample code in the readme.